### PR TITLE
Fix failing test

### DIFF
--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -5,7 +5,7 @@ import solver
 from decimal import Decimal
 
 
-@pytest.mark.parametrize("number, problems", list(enumerate(open(r"tests\test_problems.txt").readlines())))
+@pytest.mark.parametrize("number, problems", list(enumerate(open(r"tests/test_problems.txt").readlines())))
 def test_main(number, problems):
     problem, answer = problems.split("==")
     solved = solver.solve(problem)


### PR DESCRIPTION
The issue is that the runner is hosted on Ubuntu, while I'm developing the project and running the tests on Windows. Windows uses file path format with backslash (`\`), while Ubuntu doesn't.